### PR TITLE
修复文件下载出现的错误

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ name: CI/CD
 
 jobs:
   yml-md-style-and-link-checks:
-    uses: paion-data/github-actions-core/.github/workflows/yml-md-style-and-link-checks.yml@master
+    uses: paion-data/ci-cd-core/.github/workflows/yml-md-style-and-link-checks.yml@master
 
   tests:
     name: Unit & Integration Tests

--- a/src/test/groovy/com/paiondata/aliOSS/TestOSSClientSpec.groovy
+++ b/src/test/groovy/com/paiondata/aliOSS/TestOSSClientSpec.groovy
@@ -20,5 +20,25 @@ class TestOSSClientSpec extends Specification{
 
         cleanup:
         expectInputStream.close()
+        actualInputStream.close()
+    }
+
+    def "Download the file repeatedly"() {
+        given: "mock fileContent to upload and testClient"
+        final InputStream expectInputStream = new ByteArrayInputStream("test".getBytes())
+        TestOSSClient testOSSClient = new TestOSSClient()
+
+        when: "upload file by using TestOSSClient"
+        testOSSClient.putObject(BUCKET_NAME, FILE_ID, expectInputStream)
+
+        then: "download the file repeatedly and compare the file content"
+        InputStream firstInputStream = testOSSClient.getObject(BUCKET_NAME, FILE_ID).getObjectContent()
+        InputStream secondInputStream = testOSSClient.getObject(BUCKET_NAME, FILE_ID).getObjectContent()
+        firstInputStream.getText() == secondInputStream.getText()
+
+        cleanup:
+        expectInputStream.close()
+        firstInputStream.close()
+        secondInputStream.close()
     }
 }

--- a/src/test/groovy/com/paiondata/aliOSS/TestOSSClientSpec.groovy
+++ b/src/test/groovy/com/paiondata/aliOSS/TestOSSClientSpec.groovy
@@ -16,7 +16,7 @@ class TestOSSClientSpec extends Specification{
 
         then: "download file by using TestOSSClient and test the file content"
         InputStream actualInputStream = testOSSClient.getObject(BUCKET_NAME, FILE_ID).getObjectContent()
-        expectInputStream == actualInputStream
+        "test" == actualInputStream.getText()
 
         cleanup:
         expectInputStream.close()


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed
原先使用 TestOSSClient 进行文件下载的时候，会出现第二次下载时为 404 的情况，原因是没有对上传的文件的流对象进行正确的管理，现在进行修复

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
